### PR TITLE
fix fun_cast bvt bug

### DIFF
--- a/pkg/sql/plan/function/operator/cast.go
+++ b/pkg/sql/plan/function/operator/cast.go
@@ -68,7 +68,7 @@ func formatCastError(vec *vector.Vector, typ types.Type, extraInfo string) error
 		if vec.ConstVectorIsNull() {
 			errStr = fmt.Sprintf("Can't cast 'NULL' as %v type.", typ)
 		} else {
-			valueStr := strings.TrimRight(strings.TrimLeft(fmt.Sprintf("%v", vec.Col), "["), "]")
+			valueStr := strings.TrimRight(strings.TrimLeft(fmt.Sprintf("%v", vec), "["), "]")
 			shortenValueStr := shortenValueString(valueStr)
 			errStr = fmt.Sprintf("Can't cast '%s' from %v type to %v type.", shortenValueStr, vec.Typ, typ)
 		}

--- a/pkg/sql/plan/function/operators.go
+++ b/pkg/sql/plan/function/operators.go
@@ -2777,7 +2777,9 @@ var operators = map[int]Functions{
 				Args:      []types.T{types.T_uint8},
 				ReturnTyp: types.T_uint8,
 				Fn: func(vs []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
-					return vs[0], nil
+					data := vs[0].Col.([]uint8)
+					vec := vector.NewConstFixed(vs[0].Typ, vs[0].Length(), data[0])
+					return vec, nil
 				},
 			},
 			{
@@ -2787,7 +2789,9 @@ var operators = map[int]Functions{
 				Args:      []types.T{types.T_uint16},
 				ReturnTyp: types.T_uint16,
 				Fn: func(vs []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
-					return vs[0], nil
+					data := vs[0].Col.([]uint16)
+					vec := vector.NewConstFixed(vs[0].Typ, vs[0].Length(), data[0])
+					return vec, nil
 				},
 			},
 			{
@@ -2797,7 +2801,9 @@ var operators = map[int]Functions{
 				Args:      []types.T{types.T_uint32},
 				ReturnTyp: types.T_uint32,
 				Fn: func(vs []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
-					return vs[0], nil
+					data := vs[0].Col.([]uint32)
+					vec := vector.NewConstFixed(vs[0].Typ, vs[0].Length(), data[0])
+					return vec, nil
 				},
 			},
 			{
@@ -2807,7 +2813,9 @@ var operators = map[int]Functions{
 				Args:      []types.T{types.T_uint64},
 				ReturnTyp: types.T_uint64,
 				Fn: func(vs []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
-					return vs[0], nil
+					data := vs[0].Col.([]uint64)
+					vec := vector.NewConstFixed(vs[0].Typ, vs[0].Length(), data[0])
+					return vec, nil
 				},
 			},
 			{
@@ -2817,7 +2825,9 @@ var operators = map[int]Functions{
 				Args:      []types.T{types.T_int8},
 				ReturnTyp: types.T_int8,
 				Fn: func(vs []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
-					return vs[0], nil
+					data := vs[0].Col.([]int8)
+					vec := vector.NewConstFixed(vs[0].Typ, vs[0].Length(), data[0])
+					return vec, nil
 				},
 			},
 			{
@@ -2827,7 +2837,9 @@ var operators = map[int]Functions{
 				Args:      []types.T{types.T_int16},
 				ReturnTyp: types.T_int16,
 				Fn: func(vs []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
-					return vs[0], nil
+					data := vs[0].Col.([]int16)
+					vec := vector.NewConstFixed(vs[0].Typ, vs[0].Length(), data[0])
+					return vec, nil
 				},
 			},
 			{
@@ -2837,7 +2849,9 @@ var operators = map[int]Functions{
 				Args:      []types.T{types.T_int32},
 				ReturnTyp: types.T_int32,
 				Fn: func(vs []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
-					return vs[0], nil
+					data := vs[0].Col.([]int32)
+					vec := vector.NewConstFixed(vs[0].Typ, vs[0].Length(), data[0])
+					return vec, nil
 				},
 			},
 			{
@@ -2847,7 +2861,9 @@ var operators = map[int]Functions{
 				Args:      []types.T{types.T_int64},
 				ReturnTyp: types.T_int64,
 				Fn: func(vs []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
-					return vs[0], nil
+					data := vs[0].Col.([]int64)
+					vec := vector.NewConstFixed(vs[0].Typ, vs[0].Length(), data[0])
+					return vec, nil
 				},
 			},
 			{
@@ -2857,7 +2873,9 @@ var operators = map[int]Functions{
 				Args:      []types.T{types.T_float32},
 				ReturnTyp: types.T_float32,
 				Fn: func(vs []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
-					return vs[0], nil
+					data := vs[0].Col.([]float32)
+					vec := vector.NewConstFixed(vs[0].Typ, vs[0].Length(), data[0])
+					return vec, nil
 				},
 			},
 			{
@@ -2867,7 +2885,9 @@ var operators = map[int]Functions{
 				Args:      []types.T{types.T_float64},
 				ReturnTyp: types.T_float64,
 				Fn: func(vs []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
-					return vs[0], nil
+					data := vs[0].Col.([]float64)
+					vec := vector.NewConstFixed(vs[0].Typ, vs[0].Length(), data[0])
+					return vec, nil
 				},
 			},
 			{
@@ -2877,7 +2897,9 @@ var operators = map[int]Functions{
 				Args:      []types.T{types.T_decimal64},
 				ReturnTyp: types.T_decimal64,
 				Fn: func(vs []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
-					return vs[0], nil
+					data := vs[0].Col.([]types.Decimal64)
+					vec := vector.NewConstFixed(vs[0].Typ, vs[0].Length(), data[0])
+					return vec, nil
 				},
 			},
 			{
@@ -2887,7 +2909,9 @@ var operators = map[int]Functions{
 				Args:      []types.T{types.T_decimal128},
 				ReturnTyp: types.T_decimal128,
 				Fn: func(vs []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
-					return vs[0], nil
+					data := vs[0].Col.([]types.Decimal128)
+					vec := vector.NewConstFixed(vs[0].Typ, vs[0].Length(), data[0])
+					return vec, nil
 				},
 			},
 		},


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
make fun_cast.test pass.
1、fix cast error msg
2、fix UNARY_PLUS 'fn return vs[0] directly will be nil.  because vector will be GC.(I don't known why）
      you can add code like " mp[vs] =0"  after line 136 in  /pkg/sql/colexec/expr_eval.go .   make proc don't GC. but I don't think that will be a good choice